### PR TITLE
v0.8.4-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 > Version number is OC version number following by the EFI revision number
 
+## v0.8.4-2 ~ 10/29/22
+
+**OpenCore version: `0.8.4` - release**
+
+### Changes
+
+* Enables AppleSecureBoot
+* Fixes framebuffer patch to use DP on Monteray and later
+
+
+
+### ACPI list
+
+| ACPI                 | Notes |
+| -------------------- | ----- |
+| SSDT-AWAC            |       |
+| SSDT-EC-USBX-DESKTOP |       |
+| SSDT-PLUG-DRTNIA     |       |
+
+
+
+### Drivers versions
+
+| Driver      | Version | Notes |
+| ----------- | ------- | ----- |
+| OpenRuntime | OC      |       |
+
+
+
+### Kexts versions
+
+| Kext          | Version | Notes |
+| ------------- | ------- | ----- |
+| AppleALC      | 1.7.5   |       |
+| IntelMausi    | 1.0.7   |       |
+| Lilu          | 1.6.2   |       |
+| NVMeFix       | 1.1.0   |       |
+| SMCProcessor  | 1.3.0   |       |
+| SMCSuperIO    | 1.3.0   |       |
+| VirtualSMC    | 1.3.0   |       |
+| WhateverGreen | 1.6.1   |       |
+| USBMap        | 1.0     |       |
+
+
+
+### Tools list
+
+| Tool      | Version | Notes |
+| --------- | ------- | ----- |
+| OpenShell | OC      |       |
+
+
+
+
 ## v0.8.4-1 ~ 10/01/22
 
 **OpenCore version: `0.8.4` - release**

--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -120,54 +120,46 @@
 			</dict>
 			<key>PciRoot(0x0)/Pci(0x2,0x0)</key>
 			<dict>
-				<key>AAPL,GfxYTile</key>
-				<data>AQAAAA==</data>
 				<key>AAPL,ig-platform-id</key>
 				<data>BwCbPg==</data>
-				<key>AAPL,slot-name</key>
-				<string>Internal@0,2,0</string>
 				<key>device-id</key>
 				<data>mz4AAA==</data>
-				<key>device_type</key>
-				<string>VGA compatible controller</string>
-				<key>enable-hdmi-dividers-fix</key>
+				<key>framebuffer-patch-enable</key>
 				<data>AQAAAA==</data>
+				<key>framebuffer-stolenmem</key>
+				<data>AAAwAQ==</data>
 				<key>enable-hdmi20</key>
 				<data>AQAAAA==</data>
-				<key>framebuffer-con0-busid</key>
+				<key>enable-lspcon-support</key>
 				<data>AQAAAA==</data>
 				<key>framebuffer-con0-enable</key>
 				<data>AQAAAA==</data>
-				<key>framebuffer-con0-pipe</key>
-				<data>EgAAAA==</data>
+				<key>framebuffer-con0-busid</key>
+				<data>AQAAAA==</data>
+				<key>framebuffer-con0-type</key>
+				<data>AAgAAA==</data>
 				<key>framebuffer-con1-enable</key>
 				<data>AQAAAA==</data>
-				<key>framebuffer-con1-index</key>
-				<data>AwAAAA==</data>
+				<key>framebuffer-con1-busid</key>
+				<data>AgAAAA==</data>
+				<key>framebuffer-con1-has-lspcon</key>
+				<data>AQAAAA==</data>
 				<key>framebuffer-con1-pipe</key>
-				<data>EgAAAA==</data>
+				<data>CAAAAA==</data>
+				<key>framebuffer-con1-preferred-lspcon-mode</key>
+				<data>AQAAAA==</data>
 				<key>framebuffer-con1-type</key>
 				<data>AAgAAA==</data>
-				<key>framebuffer-con2-busid</key>
-				<data>AAAAAA==</data>
 				<key>framebuffer-con2-enable</key>
 				<data>AQAAAA==</data>
-				<key>framebuffer-con2-flags</key>
-				<data>IAAAAA==</data>
-				<key>framebuffer-con2-index</key>
-				<data>/////w==</data>
+				<key>framebuffer-con2-busid</key>
+				<data>BAAAAA==</data>
 				<key>framebuffer-con2-pipe</key>
-				<data>AAAAAA==</data>
+				<data>CgAAAA==</data>
 				<key>framebuffer-con2-type</key>
-				<data>AQAAAA==</data>
-				<key>framebuffer-patch-enable</key>
-				<data>AQAAAA==</data>
-				<key>framebuffer-unifiedmem</key>
-				<data>AAAAgA==</data>
-				<key>hda-gfx</key>
-				<string>onboard-1</string>
-				<key>model</key>
-				<string>Intel CometLake-S GT2 [UHD Graphics 630]</string>
+				<data>AAgAAA==</data>
+				<key>igfxfw</key>
+				<data>AgAAAA==</data>
 			</dict>
 		</dict>
 		<key>Delete</key>

--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -845,7 +845,7 @@
 			<key>AppleRtcRam</key>
 			<false/>
 			<key>AppleSecureBoot</key>
-			<false/>
+			<true/>
 			<key>AppleSmcIo</key>
 			<false/>
 			<key>AppleUserInterfaceTheme</key>


### PR DESCRIPTION
**OpenCore version: `0.8.4` - release**

### Changes

* Enables AppleSecureBoot
* Fixes framebuffer patch to use DP on Monteray and later



### ACPI list

| ACPI                 | Notes |
| -------------------- | ----- |
| SSDT-AWAC            |       |
| SSDT-EC-USBX-DESKTOP |       |
| SSDT-PLUG-DRTNIA     |       |



### Drivers versions

| Driver      | Version | Notes |
| ----------- | ------- | ----- |
| OpenRuntime | OC      |       |



### Kexts versions

| Kext          | Version | Notes |
| ------------- | ------- | ----- |
| AppleALC      | 1.7.5   |       |
| IntelMausi    | 1.0.7   |       |
| Lilu          | 1.6.2   |       |
| NVMeFix       | 1.1.0   |       |
| SMCProcessor  | 1.3.0   |       |
| SMCSuperIO    | 1.3.0   |       |
| VirtualSMC    | 1.3.0   |       |
| WhateverGreen | 1.6.1   |       |
| USBMap        | 1.0     |       |



### Tools list

| Tool      | Version | Notes |
| --------- | ------- | ----- |
| OpenShell | OC      |       |
